### PR TITLE
Fix cmake UUID link and c++ bugs found by switching to clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,8 +126,6 @@ if (ADIAK_FOUND)
 		adiak)
 endif()
 
-#list(APPEND adc_cxx_dependencies uuid)
-
 # Generate the adc_config.h header
 configure_file(adc/adc_config.h.in adc/adc_config.h)
 add_custom_target(headers ALL DEPENDS ${GENHEADERS})
@@ -143,6 +141,11 @@ blt_add_library(NAME adc_cxx
 		SOURCES    ${adc_cxx_sources}
 		DEPENDS_ON ${adc_cxx_dependencies}
 		SHARED)
+
+target_link_libraries(adc_cxx
+  PUBLIC uuid
+)
+
 
 include(GenerateExportHeader)
 generate_export_header(adc_cxx)
@@ -185,28 +188,28 @@ install(FILES
 # Define the executable targets
 blt_add_executable(NAME test.builder
 	SOURCES examples/testBuilder.cpp
-	DEPENDS_ON adc_cxx stdc++fs uuid)
+	DEPENDS_ON adc_cxx stdc++fs)
 
 blt_add_executable(NAME demo.builder
 	SOURCES examples/demoBuilder.cpp
-	DEPENDS_ON adc_cxx stdc++fs uuid)
+	DEPENDS_ON adc_cxx stdc++fs)
 
 blt_add_executable(NAME adc.hello.world.auto
 	SOURCES	examples/adcHelloWorldAuto.cpp
-	DEPENDS_ON adc_cxx stdc++fs uuid)
+	DEPENDS_ON adc_cxx stdc++fs)
 
 blt_add_executable(NAME mpi.demo.builder
 	SOURCES	examples/mpiDemoBuilder.cpp
-	DEPENDS_ON adc_cxx stdc++fs uuid)
+	DEPENDS_ON adc_cxx stdc++fs)
 
 blt_add_executable(NAME mpi.simple.demo 
 	SOURCES examples/mpiSimpleDemo.cpp
-	DEPENDS_ON adc_cxx stdc++fs uuid)
+	DEPENDS_ON adc_cxx stdc++fs)
 
 if (MPI_FOUND)
 blt_add_executable(NAME adc.hello.world.mpi 
 	SOURCES examples/adcHelloWorldMPI.cpp
-	DEPENDS_ON adc_cxx stdc++fs mpi uuid pthread)
+	DEPENDS_ON adc_cxx stdc++fs mpi pthread)
 
 install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/adc.hello.world.mpi 
 	TYPE BIN )

--- a/adc/builder/impl/builder.ipp
+++ b/adc/builder/impl/builder.ipp
@@ -433,11 +433,23 @@ void builder::add_header_section(std::string_view application_name)
 	uid_t uid = geteuid();
 	struct passwd pw;
 	struct passwd *pwp = nullptr;
-	int bsize = sysconf(_SC_GETPW_R_SIZE_MAX);
-	if (bsize < 0)
-		bsize = 16384;
-	char buf[bsize];
-	getpwuid_r(uid, &pw, buf, bsize, &pwp);
+
+	long limit = sysconf(_SC_GETPW_R_SIZE_MAX);
+	size_t bufsize = (limit > 0) ? static_cast<size_t>(limit) : 16384;
+	std::vector<char> buf;
+	while (true) {
+		buf.resize(bufsize);
+		int berr = getpwuid_r(uid, &pw, buf.data(), bufsize, &pwp);
+		if (berr == ERANGE) {
+			bufsize *= 2;
+			continue;
+		}
+		if (berr) {
+			pwp = nullptr;
+			break;
+		}
+	}
+
 	const char *uname;
 	if (pwp) {
 		uname = pw.pw_name;
@@ -1385,26 +1397,28 @@ void builder::add_mpi_section(std::string_view name, void *mpi_comm_p, adc_mpi_f
 	if ( bitflags & ADC_MPI_LIB_VER) {
 		std::ostringstream lversion;
 #ifdef OMPI_VERSION
-#define USE_set_lib_version
+		#define USE_set_lib_version
 		lversion << "OpenMPI " << OMPI_MAJOR_VERSION << "." <<
 			OMPI_MINOR_VERSION << "." << OMPI_RELEASE_VERSION;
 		goto set_lib_version;
 #else
-#ifdef MVAPICH2_VERSION
-#define USE_set_lib_version
+	#ifdef MVAPICH2_VERSION
+		#define USE_set_lib_version
 		lversion << MVAPICH2_VERSION;
 		goto set_lib_version;
-#else
-#ifdef MPICH_VERSION
-#define USE_set_lib_version
+	#else
+		#ifdef MPICH_VERSION
+		#define USE_set_lib_version
 		lversion << MPICH_VERSION;
 		goto set_lib_version;
-#endif
-#endif
+		#endif
+	#endif
 #endif
 		char lv[MPI_MAX_LIBRARY_VERSION_STRING];
+		{ 
 		int sz = 0;
 		err = MPI_Get_library_version(lv, &sz);
+		}
 		lversion << lv;
 #ifdef USE_set_lib_version
 set_lib_version:

--- a/adc/builder/impl/enums.ipp
+++ b/adc/builder/impl/enums.ipp
@@ -208,7 +208,7 @@ const std::string to_string(void *data, scalar_type cptype, size_t count) // pre
 	case cp_bool:
 		{
 			bool *a = (bool *)data;
-			for (size_t i; i < count; i++) {
+			for (size_t i = 0; i < count; i++) {
 				o << (a[i] ? "true" : "false");
 				if (i < count-1)
 					o << ", ";

--- a/adc/impl/factory.ipp
+++ b/adc/impl/factory.ipp
@@ -148,6 +148,7 @@ std::shared_ptr<multi_publisher_api> factory::get_multi_publisher(std::map< cons
 			}
 		}
 	}
+	return mp;
 }
 
 std::shared_ptr<multi_publisher_api> factory::get_multi_publisher_from_env(const std::string& namelist)

--- a/examples/cpost.json.in
+++ b/examples/cpost.json.in
@@ -1,0 +1,1 @@
+{"header":{"adc_api_version":{"version":"1.0.0","tags":["none"]},"timestamp":"@TIME@","datestamp":"@DATE@","user":"@USER@","uid":"@UID@","application":"cxx_demo_1","uuid":"@UUID@"},"foo":{"a":"bash-post"}}

--- a/examples/cpost.sh
+++ b/examples/cpost.sh
@@ -2,7 +2,17 @@
 # get the SERVER variable
 . ./cpost.include.sh
 # use the local input file with -d option
-fn=./cpost.json
+uuid=$(uuid -v4)
+uid=$(id -u)
+etime=$(date +%s.%N)
+edate=$(date +%FT%X.%N%Z)
+cat cpost.json.in | sed -e "s/@USER@/$USER/g" \
+	-e "s/@TIME@/$etime/g"  \
+	-e "s/@DATE@/$edate/g"  \
+	-e "s/@UID@/$uid/g"  \
+	-e "s/@UUID@/$uuid/g"  \
+> ./cpost.json.tmp
+fn=./cpost.json.tmp
 # write curl output to local scratch file.
 log=$(mktemp)
 curl -X POST \


### PR DESCRIPTION
- tested to work with cmake versions 3.31.0 and 3.26.5
- removes vla usage, missed initialization in builder
- provides scope hint to clang's not-accurate-enough goto/variable initialization analysis.
- fixes missing pointer return in factory