### PR TITLE
add get_names to multipublisher

### DIFF
--- a/adc/publisher/impl/multi_publisher.ipp
+++ b/adc/publisher/impl/multi_publisher.ipp
@@ -92,6 +92,15 @@ public:
 			element->resume();
 		}
 	}
+
+	std::vector< std::string > get_names()
+	{
+		std::vector< std::string > v(pvec.size());
+		for (auto& element : pvec) {
+			v.push_back( std::string(element->name()));
+		}
+		return v;
+	}
 };  // class multi_publisher
 
 } // namespace adc

--- a/adc/publisher/multi_publisher.hpp
+++ b/adc/publisher/multi_publisher.hpp
@@ -48,6 +48,8 @@ public:
 	/// @brief Resume all publishers
         virtual void resume() = 0;
 
+	/// @brief List names of all configured publishers
+	virtual std::vector< std::string >get_names() = 0;
 
 	virtual ~multi_publisher_api() {}
 };


### PR DESCRIPTION
the application runtime may wish to discover whta plugins are active, if configured from the environment variables.